### PR TITLE
Align resource key and data file environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ data file.
 
 [ip-intelligence-data](https://github.com/51Degrees/ip-intelligence-data/) repository instructs how to obtain a 'Lite' data file, otherwise [contact us](https://51degrees.com/contact-us) to obtain an 'Enterprise' data file.
 
+For tests, the data file can be supplied explicitly by setting the
+`51DEGREES_IPI_PATH` environment variable or system property to the path of
+the .ipi file. When it is not set, the project space is searched for the
+expected file name, with the free 'Lite' file expected in the
+[ip-intelligence-data](https://github.com/51Degrees/ip-intelligence-data/)
+location.
+
 ## Installation
 
 Our latest release is available as compiled JARs on Maven - or you can compile from source as described below.
@@ -104,6 +111,13 @@ repository.
 
 You will need [resource keys](https://51degrees.com/documentation/_info__resource_keys.html)
 (see above) to complete the tests and run examples which include exercising the cloud API.
+
+The tests look for a resource key in the following order:
+
+1. The aligned `51DEGREES_RESOURCE_KEY` name, set as an environment variable
+   or as a system property.
+2. The legacy `TestResourceKey` name, which is still supported and is checked
+   after the aligned name.
 
 To verify the code:
 

--- a/ip-intelligence.cloud/src/test/java/fiftyone/ipintelligence/cloud/WrapperCloud.java
+++ b/ip-intelligence.cloud/src/test/java/fiftyone/ipintelligence/cloud/WrapperCloud.java
@@ -47,7 +47,7 @@ public class WrapperCloud implements Closeable {
     public WrapperCloud() throws Exception {
         cloudRequestEngine = 
                 new CloudRequestEngineBuilder(loggerFactory)
-                .setResourceKey(KeyUtils.getNamedKey("TestResourceKey"))
+                .setResourceKey(KeyUtils.getResourceKey("TestResourceKey"))
                 .build();
         IPIntelligenceCloudEngine = new IPIntelligenceCloudEngineBuilder(loggerFactory)
                 .build();

--- a/ip-intelligence.shared/src/main/java/fiftyone/ipintelligence/shared/testhelpers/FileUtils.java
+++ b/ip-intelligence.shared/src/main/java/fiftyone/ipintelligence/shared/testhelpers/FileUtils.java
@@ -38,6 +38,13 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class FileUtils {
+    /**
+     * Name of the aligned environment variable or system property which can
+     * supply an explicit path to the IPI data file. When set and the file
+     * exists it is used in preference to searching the project space.
+     */
+    public static final String IPI_PATH_ENV_VAR = "51DEGREES_IPI_PATH";
+
     public static final String ENTERPRISE_IPI_DATA_FILE_NAME = "Enterprise-IpIntelligenceV41.ipi";
 
     public static final String ENTERPRISE_IPI_V41_DATA_FILE_NAME = "51Degrees-EnterpriseIpiV41.ipi";
@@ -63,6 +70,10 @@ public class FileUtils {
      * @return a file or empty if not found
      */
     public static File getHashFile() {
+        File explicitFile = getExplicitHashFile();
+        if (Objects.nonNull(explicitFile)) {
+            return explicitFile;
+        }
         try {
             if (Objects.nonNull(IPI_DATA_FILE)){
                 return IPI_DATA_FILE.orElse(null);
@@ -86,6 +97,26 @@ public class FileUtils {
                 }
             }
         }
+    }
+
+    /**
+     * Check the aligned {@link #IPI_PATH_ENV_VAR} environment variable and
+     * system property for an explicit path to the IPI data file.
+     *
+     * @return a file if the path is set and the file exists, otherwise null
+     */
+    private static File getExplicitHashFile() {
+        String explicitPath = System.getenv(IPI_PATH_ENV_VAR);
+        if (Objects.isNull(explicitPath)) {
+            explicitPath = System.getProperty(IPI_PATH_ENV_VAR);
+        }
+        if (Objects.nonNull(explicitPath)) {
+            File explicitFile = new File(explicitPath);
+            if (explicitFile.exists()) {
+                return explicitFile;
+            }
+        }
+        return null;
     }
 
     public static File getEvidenceFile() {

--- a/ip-intelligence.shared/src/main/java/fiftyone/ipintelligence/shared/testhelpers/KeyUtils.java
+++ b/ip-intelligence.shared/src/main/java/fiftyone/ipintelligence/shared/testhelpers/KeyUtils.java
@@ -30,6 +30,29 @@ import java.util.Objects;
  */
 public class KeyUtils {
     /**
+     * Name of the aligned environment variable or system property which
+     * supplies the resource key. This name is checked before any legacy name.
+     */
+    public static final String RESOURCE_KEY_ENV_VAR = "51DEGREES_RESOURCE_KEY";
+
+    /**
+     * Obtain a resource key from an environment variable or a system property.
+     * <p>
+     * The aligned name {@link #RESOURCE_KEY_ENV_VAR} is checked first and the
+     * supplied legacy name is checked second. Each name is looked up using
+     * {@link #getNamedKey(String)}.
+     * @param legacyKeyName legacy name to try when the aligned name is not set
+     * @return the resource key, or null if neither name is set
+     */
+    public static String getResourceKey(String legacyKeyName) {
+        String resourceKey = getNamedKey(RESOURCE_KEY_ENV_VAR);
+        if (Objects.isNull(resourceKey)) {
+            resourceKey = getNamedKey(legacyKeyName);
+        }
+        return resourceKey;
+    }
+
+    /**
      * Obtain a key either from environment variable or from a property.
      * <p>
      * Try resource key as env var, then as upper case env var, the system property


### PR DESCRIPTION
## Summary

This change aligns the environment variable names used by the test helpers with the convention shared across 51Degrees repositories.

- `KeyUtils` gains an aligned-first lookup. The `51DEGREES_RESOURCE_KEY` name is checked first as an environment variable or system property, with the legacy `TestResourceKey` name retained and checked second.
- `FileUtils` checks the `51DEGREES_IPI_PATH` name for an explicit data file path before the existing project space search, which is unchanged.
- The README documents the resolution order.

## Notes

- Maven `-D` parameter names used by CI are unchanged, so existing pipelines keep working.
- GitHub workflow secret references are unchanged. An accompanying issue advises on the aligned secret naming.
- The aligned names start with a digit, which POSIX shells do not accept in plain assignments. On Linux and macOS set them with the env command or pass them as system properties, for example `mvn test -D51DEGREES_RESOURCE_KEY=AAA`.
