### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees IP Intelligence Engines
 
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=java-open-source "Data rewards the curious") **Java IP Intelligence**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=readme.md&utm_term=51degrees-ip-intelligence-engines "Data rewards the curious") **Java IP Intelligence**
 
-[Developer Documentation](https://51degrees.com/ip-intelligence-java/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=java-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/ip-intelligence-java/index.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=readme.md&utm_term=51degrees-ip-intelligence-engines "developer documentation")
 
 ## Introduction
 
@@ -10,8 +10,8 @@ This repository contains Java implementation of the IP Intelligence [specificati
 
 ## Dependencies
 
-For runtime dependencies, see our [dependencies](http://51degrees.com/documentation/_info__dependencies.html) page.
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows 
+For runtime dependencies, see our [dependencies](https://51degrees.com/documentation/_info__dependencies.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=readme.md&utm_term=dependencies) page.
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=readme.md&utm_term=dependencies) page shows 
 the JDK versions that we currently test against. The software may run fine against other versions, 
 but additional caution should be applied.
 
@@ -23,9 +23,9 @@ The Java API can either use our cloud service to get its data or it can use a lo
 
 The cloud service for IP Intelligence is currently in development.
 
-You will require [resource keys](https://51degrees.com/documentation/_info__resource_keys.html)
+You will require [resource keys](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=readme.md&utm_term=cloud-coming-soon)
 to use the Cloud API, as described on our website. Get resource keys from
-our [configurator](https://configure.51degrees.com/), see our [documentation](https://51degrees.com/documentation/_concepts__configurator.html) on 
+our [configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=readme.md&utm_term=cloud-coming-soon), see our [documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=readme.md&utm_term=cloud-coming-soon) on 
 how to use this.
 
 #### On-Premise
@@ -33,7 +33,7 @@ how to use this.
 In order to perform IP intelligence on-premise, you will need to use a
 data file.
 
-[ip-intelligence-data](https://github.com/51Degrees/ip-intelligence-data/) repository instructs how to obtain a 'Lite' data file, otherwise [contact us](https://51degrees.com/contact-us) to obtain an 'Enterprise' data file.
+[ip-intelligence-data](https://github.com/51Degrees/ip-intelligence-data/) repository instructs how to obtain a 'Lite' data file, otherwise [contact us](https://51degrees.com/contact-us?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=readme.md&utm_term=on-premise) to obtain an 'Enterprise' data file.
 
 For tests, the data file can be supplied explicitly by setting the
 `51DEGREES_IPI_PATH` environment variable or system property to the path of
@@ -109,7 +109,7 @@ repository.
 
 ## Tests
 
-You will need [resource keys](https://51degrees.com/documentation/_info__resource_keys.html)
+You will need [resource keys](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=readme.md&utm_term=tests)
 (see above) to complete the tests and run examples which include exercising the cloud API.
 
 The tests look for a resource key in the following order:

--- a/ci/README.md
+++ b/ci/README.md
@@ -6,11 +6,11 @@ The following secrets are required:
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
   
 The following secrets are required to run on-premise tests:
-* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing) for downloading assets (enterprise IPI data file)
+* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for downloading assets (enterprise IPI data file)
     * Example: `V3RYL0NGR4ND0M57R1NG`
  
 The following secrets are requred to run cloud tests:
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=ip-intelligence-java&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`
 
 The following secrets are required for publishing releases (this should only be needed by 51Degrees):

--- a/ip-intelligence.cloud/pom.xml
+++ b/ip-intelligence.cloud/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>ip-intelligence.cloud</artifactId>
     <name>51Degrees :: IP Intelligence :: Cloud</name>
     <description>Provides IP Intelligence for the 51Degrees Pipeline API using the 51Degrees Cloud service. This can be used as an alternative to legacy IP Intelligence services such as MaxMind or IPinfo.</description>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-java&amp;utm_content=ip-intelligence.cloud-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/ip-intelligence.engine.on-premise/pom.xml
+++ b/ip-intelligence.engine.on-premise/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>ip-intelligence.engine.on-premise</artifactId>
     <name>51Degrees :: IP Intelligence :: On Premise</name>
 	<description>Provides the On-premise IP Intelligence engine for the 51Degrees Pipeline API. This can be used as an alternative to legacy IP Intelligence services such as MaxMind or IPinfo.</description>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-java&amp;utm_content=ip-intelligence.engine.on-premise-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/ip-intelligence.engine.on-premise/src/main/java/fiftyone/ipintelligence/engine/onpremise/flowelements/IPIntelligenceOnPremiseEngineBuilder.java
+++ b/ip-intelligence.engine.on-premise/src/main/java/fiftyone/ipintelligence/engine/onpremise/flowelements/IPIntelligenceOnPremiseEngineBuilder.java
@@ -172,7 +172,7 @@ public class IPIntelligenceOnPremiseEngineBuilder
      * Provide a hint as to how many threads will access the pipeline simultaneously
      * <p>
      * Default is the result of {@link Runtime#getRuntime()#getAvailableProcessors()}
-     * @see <a href="https://51degrees.com/documentation/_device_detection__features__concurrent_processing.html">Concurrent processing</a>
+     * @see <a href="https://51degrees.com/documentation/_device_detection__features__concurrent_processing.html?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=ip-intelligence-java&amp;utm_content=ip-intelligence.engine.on-premise-src-main-java-fiftyone-ipintelligence-engine-onpremise-flowelements-ipintelligenceonpremiseenginebuilder.java&amp;utm_term=setconcurrency">Concurrent processing</a>
      * @param concurrency expected concurrent accesses
      * @return this builder
      */

--- a/ip-intelligence.shared/pom.xml
+++ b/ip-intelligence.shared/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>ip-intelligence.shared</artifactId>
     <name>51Degrees :: IP Intelligence :: Shared</name>
     <description>Shared code used by 51Degrees IP Intelligence modules for the Pipeline API.</description>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-java&amp;utm_content=ip-intelligence.shared-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/ip-intelligence/pom.xml
+++ b/ip-intelligence/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>ip-intelligence</artifactId>
     <name>51Degrees :: IP Intelligence</name>
     <description>Provides IP Intelligence for the 51Degrees Pipeline API. This can be used as an alternative to legacy IP Intelligence services such as MaxMind or IPinfo.</description>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-java&amp;utm_content=ip-intelligence-pom.xml&amp;utm_term=url</url>
 
     <dependencies>
         <dependency>

--- a/ip-intelligence/src/main/java/fiftyone/ipintelligence/IPIntelligencePipelineBuilder.java
+++ b/ip-intelligence/src/main/java/fiftyone/ipintelligence/IPIntelligencePipelineBuilder.java
@@ -110,7 +110,7 @@ public class IPIntelligencePipelineBuilder {
     /**
      * Use the 51Degrees Cloud service to perform IP Intelligence.
      * @param resourceKey The resource key to use when querying the Cloud service. 
-     * Obtain one from https://configure.51degrees.com
+     * Obtain one from https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=ip-intelligence-java&amp;utm_content=ip-intelligence-src-main-java-fiftyone-ipintelligence-ipintelligencepipelinebuilder.java&amp;utm_term=usecloud
      * @return A builder that can be used to configure and build a pipeline
      * that will use the Cloud IP Intelligence engine.
      */

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <name>51Degrees :: Pipeline :: IP Intelligence</name>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=ip-intelligence-java&amp;utm_content=pom.xml&amp;utm_term=url</url>
     <description>IP Intelligence engines for the 51Degrees Pipeline API</description>
 
     <modules>


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

18 links across 10 files, in-place URL replacements only. While tagging, http, www, and protocol-relative variants were normalised to https on the bare domain, pre-2026 utm schemes were replaced, and the retired Logo.ashx banner URL was replaced with img/logo.png where present. Functional endpoints (cloud, distributor, devices-v4, bulkdata), test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).