### PR TITLE
FEAT: Raise Unused code during build stage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/ci/pmd-ruleset.xml
+++ b/ci/pmd-ruleset.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="51Degrees Unused Code"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        Reports unused code as part of the build. The Java compiler's -Xlint
+        cannot detect unused local variables, private fields, private methods or
+        private/constructor parameters, so these slip through unnoticed. PMD fills
+        that gap. Kept deliberately narrow (unused declarations only) so the gate
+        stays meaningful and low-noise.
+
+        Note: there is no reliable rule for "unused public class/method" - those may
+        form part of the published API and cannot be judged from this codebase alone,
+        so they are intentionally out of scope.
+    </description>
+
+    <!-- Unused local variables, e.g. `Path tempPath = ...;` that is never read. -->
+    <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
+
+    <!-- Private fields that are never read. -->
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
+
+    <!-- Private methods that are never called. -->
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
+
+    <!-- Parameters of private methods/constructors that are never used.
+         (Restricted to private members by default so overrides and interface
+         implementations are not flagged.) -->
+    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
+
+    <!-- Imports that are not referenced (also covers duplicate/unnecessary imports). -->
+    <rule ref="category/java/codestyle.xml/UnnecessaryImport"/>
+
+</ruleset>

--- a/ci/pmd-ruleset.xml
+++ b/ci/pmd-ruleset.xml
@@ -7,11 +7,9 @@
     <description>
         Reports unused code as part of the build. The Java compiler's -Xlint
         cannot detect unused local variables, private fields, private methods or
-        private/constructor parameters, so these slip through unnoticed. PMD fills
-        that gap. Kept deliberately narrow (unused declarations only) so the gate
-        stays meaningful and low-noise.
+        private/constructor parameters.
 
-        Note: there is no reliable rule for "unused public class/method" - those may
+        Note: there is no reliable rule for "unused public class/method" as those may
         form part of the published API and cannot be judged from this codebase alone,
         so they are intentionally out of scope.
     </description>

--- a/ip-intelligence.cloud/src/main/java/fiftyone/ipintelligence/cloud/data/MultiIPIDataCloud.java
+++ b/ip-intelligence.cloud/src/main/java/fiftyone/ipintelligence/cloud/data/MultiIPIDataCloud.java
@@ -41,7 +41,7 @@ import java.util.Map;
  * by the 51Degrees Cloud service when evidence matching multiple profiles is
  * provided.
  */
-public class MultiIPIDataCloud
+public final class MultiIPIDataCloud
     extends AspectDataBase
     implements MultiProfileData<IPIntelligenceData> {
     private static final String PROFILE_LIST_KEY = "profiles";

--- a/ip-intelligence.cloud/src/test/java/fiftyone/ipintelligence/cloud/flowelements/IPIntelligenceCloudEngineTests.java
+++ b/ip-intelligence.cloud/src/test/java/fiftyone/ipintelligence/cloud/flowelements/IPIntelligenceCloudEngineTests.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/ip-intelligence.cloud/src/test/java/fiftyone/ipintelligence/cloud/flowelements/MissingPropertyHandlingTests.java
+++ b/ip-intelligence.cloud/src/test/java/fiftyone/ipintelligence/cloud/flowelements/MissingPropertyHandlingTests.java
@@ -26,7 +26,6 @@ import fiftyone.ipintelligence.cloud.data.IPIntelligenceDataCloud;
 import fiftyone.pipeline.cloudrequestengine.data.CloudRequestData;
 import fiftyone.pipeline.cloudrequestengine.flowelements.CloudRequestEngine;
 import fiftyone.pipeline.core.data.FlowData;
-import fiftyone.pipeline.core.data.IWeightedValue;
 import fiftyone.pipeline.engines.data.AspectPropertyMetaData;
 import fiftyone.pipeline.engines.data.AspectPropertyMetaDataDefault;
 import fiftyone.pipeline.engines.data.AspectPropertyValue;

--- a/ip-intelligence.engine.on-premise/src/test/java/fiftyone/ipintelligence/engine/onpremise/data/DataValidatorHash.java
+++ b/ip-intelligence.engine.on-premise/src/test/java/fiftyone/ipintelligence/engine/onpremise/data/DataValidatorHash.java
@@ -26,13 +26,10 @@ import fiftyone.ipintelligence.engine.onpremise.flowelements.IPIntelligenceOnPre
 import fiftyone.ipintelligence.shared.IPIntelligenceData;
 import fiftyone.ipintelligence.shared.testhelpers.data.DataValidator;
 import fiftyone.pipeline.core.data.FlowData;
-import fiftyone.pipeline.core.data.IWeightedValue;
 import fiftyone.pipeline.engines.data.AspectPropertyValue;
 import fiftyone.pipeline.engines.exceptions.NoValueException;
 import fiftyone.pipeline.engines.fiftyone.data.FiftyOneAspectPropertyMetaData;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;

--- a/ip-intelligence.shared/src/main/java/fiftyone/ipintelligence/shared/flowelements/OnPremiseIPIntelligenceEngineBuilderBase.java
+++ b/ip-intelligence.shared/src/main/java/fiftyone/ipintelligence/shared/flowelements/OnPremiseIPIntelligenceEngineBuilderBase.java
@@ -24,7 +24,6 @@ package fiftyone.ipintelligence.shared.flowelements;
 
 import fiftyone.pipeline.engines.data.AspectData;
 import fiftyone.pipeline.engines.data.AspectPropertyMetaData;
-import fiftyone.pipeline.engines.data.AspectPropertyValue;
 import fiftyone.pipeline.engines.fiftyone.flowelements.FiftyOneAspectEngine;
 import fiftyone.pipeline.engines.fiftyone.flowelements.FiftyOneOnPremiseAspectEngineBuilderBase;
 import fiftyone.pipeline.engines.services.DataUpdateService;

--- a/ip-intelligence.shared/src/test/java/fiftyone/ipintelligence/shared/testhelpers/FileUtilsTest.java
+++ b/ip-intelligence.shared/src/test/java/fiftyone/ipintelligence/shared/testhelpers/FileUtilsTest.java
@@ -22,7 +22,6 @@
 
 package fiftyone.ipintelligence.shared.testhelpers;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ip-intelligence.shared/src/test/java/fiftyone/ipintelligence/shared/testhelpers/ListRuntimeConfigTest.java
+++ b/ip-intelligence.shared/src/test/java/fiftyone/ipintelligence/shared/testhelpers/ListRuntimeConfigTest.java
@@ -22,7 +22,6 @@
 
 package fiftyone.ipintelligence.shared.testhelpers;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class ListRuntimeConfigTest {

--- a/ip-intelligence.shared/src/test/java/fiftyone/ipintelligence/shared/testhelpers/data/MetaDataTests.java
+++ b/ip-intelligence.shared/src/test/java/fiftyone/ipintelligence/shared/testhelpers/data/MetaDataTests.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 

--- a/ip-intelligence.shared/src/test/java/fiftyone/ipintelligence/shared/testhelpers/data/ValueTests.java
+++ b/ip-intelligence.shared/src/test/java/fiftyone/ipintelligence/shared/testhelpers/data/ValueTests.java
@@ -33,7 +33,10 @@ import fiftyone.pipeline.engines.exceptions.PropertyMissingException;
 import fiftyone.pipeline.engines.fiftyone.data.FiftyOneAspectPropertyMetaData;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static fiftyone.pipeline.util.StringManipulation.stringJoin;
 import static org.junit.Assert.*;

--- a/ip-intelligence.shared/src/test/java/fiftyone/ipintelligence/shared/testhelpers/flowelements/ProcessTests.java
+++ b/ip-intelligence.shared/src/test/java/fiftyone/ipintelligence/shared/testhelpers/flowelements/ProcessTests.java
@@ -27,10 +27,7 @@ import fiftyone.ipintelligence.shared.testhelpers.Wrapper;
 import fiftyone.ipintelligence.shared.testhelpers.data.DataValidator;
 import fiftyone.pipeline.core.data.FlowData;
 
-import java.util.Arrays;
-import java.util.List;
 
-import static fiftyone.pipeline.util.StringManipulation.stringJoin;
 
 public class ProcessTests {
 

--- a/ip-intelligence/src/main/java/fiftyone/ipintelligence/IPIntelligenceOnPremisePipelineBuilder.java
+++ b/ip-intelligence/src/main/java/fiftyone/ipintelligence/IPIntelligenceOnPremisePipelineBuilder.java
@@ -34,7 +34,6 @@ import fiftyone.pipeline.engines.fiftyone.flowelements.ShareUsageBuilder;
 import fiftyone.pipeline.engines.flowelements.AspectEngine;
 import fiftyone.pipeline.engines.flowelements.PrePackagedPipelineBuilderBase;
 import fiftyone.pipeline.engines.services.DataUpdateService;
-import fiftyone.pipeline.engines.services.HttpClient;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 

--- a/ip-intelligence/src/test/java/fiftyone/ipintelligence/IPIntelligenceOnPremisePipelineBuilderTest.java
+++ b/ip-intelligence/src/test/java/fiftyone/ipintelligence/IPIntelligenceOnPremisePipelineBuilderTest.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -160,7 +159,7 @@ public class IPIntelligenceOnPremisePipelineBuilderTest {
     @Test
     public void setDataUpdateService_RegisterDataFileTriggered() throws Exception {
         DataUpdateServiceDefault dataUpdateServiceDefault = mock(DataUpdateServiceDefault.class);
-        Pipeline pipeline = builder
+        builder
                 .setAutoUpdate(true)
                 .setDataUpdateService(dataUpdateServiceDefault)
                 .build();

--- a/ip-intelligence/src/test/java/fiftyone/ipintelligence/IPIntelligenceTests.java
+++ b/ip-intelligence/src/test/java/fiftyone/ipintelligence/IPIntelligenceTests.java
@@ -58,7 +58,6 @@ import static fiftyone.ipintelligence.shared.testhelpers.FileUtils.IP_ADDRESSES_
 import static fiftyone.pipeline.engines.Constants.PerformanceProfiles.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/ip-intelligence/src/test/java/fiftyone/ipintelligence/IPIntelligenceTests.java
+++ b/ip-intelligence/src/test/java/fiftyone/ipintelligence/IPIntelligenceTests.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -56,6 +57,7 @@ import java.util.concurrent.Future;
 import static fiftyone.ipintelligence.shared.testhelpers.FileUtils.IP_ADDRESSES_FILE_NAME;
 import static fiftyone.pipeline.engines.Constants.PerformanceProfiles.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -230,6 +232,8 @@ public class IPIntelligenceTests {
                         pipeline.getElement(IPIntelligenceOnPremiseEngine.class);
                 String tempDir = engine.getTempDataDirPath();
                 Path tempPath = Paths.get(tempDir);
+                assertTrue("A temp data file should have been created under " + tempPath,
+                        Files.exists(tempPath));
             }
         }
         logger.info("Completed {} creations", i);

--- a/pom.xml
+++ b/pom.xml
@@ -163,9 +163,9 @@
                 <!--
                     Reports unused code (local variables, private fields, private
                     methods, private parameters and unnecessary imports) as part of
-                    the build. javac's -Xlint cannot detect these, so they were going
-                    unnoticed. Bound to the compile phase so violations surface during
-                    a normal build and fail it. Rules are defined in ci/pmd-ruleset.xml.
+                    the build. javac's -Xlint cannot detect these.
+                     Bound to the compile phase so violations surface during
+                    a normal build and fail it.
                 -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
@@ -175,7 +175,7 @@
                         <!--suppress UnresolvedMavenProperty -->
                         <ruleset>${maven.multiModuleProjectDirectory}/ci/pmd-ruleset.xml</ruleset>
                     </rulesets>
-                    <!-- Analyse test sources too - that is where unused code commonly hides. -->
+                    <!-- Analyse test sources -->
                     <includeTests>true</includeTests>
                     <failOnViolation>true</failOnViolation>
                     <printFailingErrors>true</printFailingErrors>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,11 @@
                     <printFailingErrors>true</printFailingErrors>
                     <!-- Avoid requiring the site/jxr report just to run the check. -->
                     <linkXRef>false</linkXRef>
+                    <!-- SWIG-generated interop bindings are machine-generated and
+                         regenerated from the native build, so they must not be gated. -->
+                    <excludes>
+                        <exclude>**/interop/swig/*.java</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
                         <showWarnings>true</showWarnings>
                         <compilerArgs>
                             <arg>-Xlint:all,-try,-options</arg>
-<!--                            <arg>-Werror</arg>-->
+                            <arg>-Werror</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <org.json.version>20211205</org.json.version>
 
         <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>
+        <maven-pmd-plugin.version>3.26.0</maven-pmd-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
@@ -157,6 +158,39 @@
                     <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil>
                 </configuration>
+            </plugin>
+            <plugin>
+                <!--
+                    Reports unused code (local variables, private fields, private
+                    methods, private parameters and unnecessary imports) as part of
+                    the build. javac's -Xlint cannot detect these, so they were going
+                    unnoticed. Bound to the compile phase so violations surface during
+                    a normal build and fail it. Rules are defined in ci/pmd-ruleset.xml.
+                -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>${maven-pmd-plugin.version}</version>
+                <configuration>
+                    <rulesets>
+                        <!--suppress UnresolvedMavenProperty -->
+                        <ruleset>${maven.multiModuleProjectDirectory}/ci/pmd-ruleset.xml</ruleset>
+                    </rulesets>
+                    <!-- Analyse test sources too - that is where unused code commonly hides. -->
+                    <includeTests>true</includeTests>
+                    <failOnViolation>true</failOnViolation>
+                    <printFailingErrors>true</printFailingErrors>
+                    <!-- Avoid requiring the site/jxr report just to run the check. -->
+                    <linkXRef>false</linkXRef>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-unused-code</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Problem
Closes #84 
Unused variables (and other unused declarations) were not being reported at
build time. The Java compiler already runs with `-Xlint:all` in this repo, but
`-Xlint` fundamentally cannot detect unused local variables, unused private
fields, unused private methods, or unused private parameters.

Example that went undetected: an unused `Path tempPath` local in
`TestOnPremiseBuilder_CreateTempFile`.

FIX: address compiler warnings:
Fix this-escape warning in MultiIPIDataCloud
Declare MultiIPIDataCloud final to resolve the "possible 'this' escape
before subclass is fully initialized" warning emitted by javac on JDK 21+

Replace java.util wildcard import in ValueTests with explicit imports
Expand `import java.util.*` to the four types the test actually uses
(ArrayList, Arrays, List, Map) in the shared module's ValueTests helper.

Uncomment -Werror to make sure no warning regressions are introduced.

## Expected behaviour

Unused variables, methods, and similar dead declarations should be reported
during the build.

## Change

Introduce [PMD](https://pmd.github.io/) via `maven-pmd-plugin` in the parent
POM:

- **`ci/pmd-ruleset.xml`** introduces a deliberately narrow ruleset:
  - unused local variables
  - unused private fields
  - unused private methods
  - unused private/constructor parameters
  - unnecessary (unused/duplicate) imports
- **`pom.xml`**: `maven-pmd-plugin` added to the parent build (inherited by all
  four modules), bound to the **`compile`** phase with **`failOnViolation=true`**
  and **`includeTests=true`**. Unused code now surfaces during a normal build and
  fails it.
- **`IPIntelligenceTests.java`**: fix the unused `Path tempPath` local exposed
  by the new check by asserting the temp data file is actually created.

## Notes / scope

- Because the gate fails the build, the first CI run may surface additional
  pre-existing unused-code violations beyond the one fixed here. These need to be
  cleaned up)for the build to go green.

## Testing

- XML well-formedness of `pom.xml` and `ci/pmd-ruleset.xml` validated locally.

