### PR TITLE
handle WktString and Single cloud property types

### DIFF
--- a/ci/generate-accessors.ps1
+++ b/ci/generate-accessors.ps1
@@ -1,11 +1,10 @@
 param (
     [Parameter(Mandatory)][string]$RepoName,
-    [string]$MetaDataPath = "$PWD/common-metadata",
     [string]$DataType = "IpIntelligence"
 )
 $ErrorActionPreference = "Stop"
 
-./tools/ci/generate-accessors.ps1 -RepoName:$RepoName -MetaDataPath:$MetaDataPath -DataType:$DataType
+./tools/ci/generate-accessors.ps1 -DataType:$DataType
 
 Copy-Item "tools/Java/IPIntelligenceDataBase.java" "ip-intelligence-java/ip-intelligence.shared/src/main/java/fiftyone/ipintelligence/shared/"
 Copy-Item "tools/Java/IPIntelligenceData.java" "ip-intelligence-java/ip-intelligence.shared/src/main/java/fiftyone/ipintelligence/shared/"

--- a/ip-intelligence.cloud/src/main/java/fiftyone/ipintelligence/cloud/flowelements/IPIntelligenceCloudEngine.java
+++ b/ip-intelligence.cloud/src/main/java/fiftyone/ipintelligence/cloud/flowelements/IPIntelligenceCloudEngine.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 
 import fiftyone.pipeline.core.data.IWeightedValue;
 import fiftyone.pipeline.core.data.WeightedValue;
+import fiftyone.pipeline.core.data.WktString;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -157,6 +158,11 @@ public class IPIntelligenceCloudEngine
                             property.getName(),
                             getInetAddressAspectPropertyValue(ipiObj, property));
                         break;
+                    case ("WktString"):
+                        propertyMap.put(
+                            property.getName(),
+                            getWktStringAspectPropertyValue(ipiObj, property));
+                        break;
                     case ("boolean"):
                         propertyMap.put(
                             property.getName(),
@@ -171,6 +177,11 @@ public class IPIntelligenceCloudEngine
                         propertyMap.put(
                             property.getName(),
                             getDoubleAspectPropertyValue(ipiObj, property));
+                        break;
+                    case ("Float"):
+                        propertyMap.put(
+                            property.getName(),
+                            getFloatAspectPropertyValue(ipiObj, property));
                         break;
                     default:
                         propertyMap.put(
@@ -273,8 +284,14 @@ public class IPIntelligenceCloudEngine
      *       {@link List} and read by the existing list handling.</li>
      *   <li>{@code IPAddress} is parsed into an {@link InetAddress} so the
  *       typed getters (e.g. {@code getIp()}) return the expected type.</li>
+     *   <li>{@code WktString} (e.g. the {@code Areas} property) is wrapped in a
+     *       {@link WktString} so the typed getter ({@code getAreas()}) returns
+     *       the expected type.</li>
      * </ul>
-     * Any other type is delegated to the shared metadata mapping.
+     * Any other type is delegated to the shared metadata mapping, which only
+     * knows the scalar cloud types and throws on anything else - so every IP
+     * Intelligence specific cloud type must be handled here (mirroring
+     * {@code IpiCloudEngine.GetPropertyType} in ip-intelligence-dotnet).
      * @param item the cloud property meta data
      * @return the Java type to use for the property
      */
@@ -286,6 +303,15 @@ public class IPIntelligenceCloudEngine
             }
             if (item.type.equals("IPAddress")) {
                 return InetAddress.class;
+            }
+            if (item.type.equals("WktString")) {
+                return WktString.class;
+            }
+            // The cloud is a .NET service and reports 32-bit floats (e.g.
+            // Latitude/Longitude) as "Single"; the shared mapping only knows
+            // "Double", so map it here to the Float the typed getters expect.
+            if (item.type.equals("Single")) {
+                return Float.class;
             }
         }
         return item.getPropertyType();
@@ -323,6 +349,27 @@ public class IPIntelligenceCloudEngine
             doubleValue.setValue(ipiObj.getDouble(key));
         }
         return doubleValue;
+    }
+
+    /**
+     * Get the {@link Float} representation of a value from the cloud engine's
+     * JSON response, and wrap it in an {@link AspectPropertyValue}. Used for
+     * cloud "Single" properties (e.g. Latitude/Longitude).
+     * @param ipiObj to get the value from
+     * @param property to get the value of
+     * @return {@link AspectPropertyValue} with a parsed value, or the reason
+     * for the value not being present
+     */
+    private AspectPropertyValue<Float> getFloatAspectPropertyValue(JSONObject ipiObj, AspectPropertyMetaData property) {
+        String key = property.getName().toLowerCase();
+        AspectPropertyValue<Float> floatValue = new AspectPropertyValueDefault<>();
+        if(ipiObj.isNull(key)){
+            floatValue.setNoValueMessage(getNoValueReason(ipiObj, key));
+        }
+        else {
+            floatValue.setValue(ipiObj.getFloat(key));
+        }
+        return floatValue;
     }
 
     /**
@@ -460,6 +507,38 @@ public class IPIntelligenceCloudEngine
             jsValue.setValue(new JavaScript(ipiObj.getString(key)));
         }
         return jsValue;
+    }
+
+    /**
+     * Get the {@link WktString} representation of a value from the cloud
+     * engine's JSON response, and wrap it in an {@link AspectPropertyValue}.
+     * The cloud serialises WKT geometry (e.g. the {@code Areas} property) as an
+     * object wrapping the text under a {@code "value"} key, so the text is
+     * extracted and wrapped in a {@link WktString} to match the typed getter
+     * ({@code getAreas()}).
+     * @param ipiObj to get the value from
+     * @param property to get the value of
+     * @return {@link AspectPropertyValue} with a parsed value, or the reason
+     * for the value not being present
+     */
+    private AspectPropertyValue<WktString> getWktStringAspectPropertyValue(
+        JSONObject ipiObj,
+        AspectPropertyMetaData property){
+        String key = property.getName().toLowerCase();
+        AspectPropertyValue<WktString> wktValue = new AspectPropertyValueDefault<>();
+        if(ipiObj.isNull(key)){
+            wktValue.setNoValueMessage(getNoValueReason(ipiObj, key));
+        } else {
+            // The cloud serialises WKT geometry as an object that wraps the
+            // text under a "value" key, e.g. {"value":"POLYGON((...))"};
+            // fall back to a plain string for forward compatibility.
+            Object raw = ipiObj.get(key);
+            String wkt = (raw instanceof JSONObject)
+                ? ((JSONObject) raw).getString("value")
+                : ipiObj.getString(key);
+            wktValue.setValue(new WktString(wkt));
+        }
+        return wktValue;
     }
 
     /**

--- a/ip-intelligence.cloud/src/test/java/fiftyone/ipintelligence/cloud/flowelements/IPIntelligenceCloudEngineTests.java
+++ b/ip-intelligence.cloud/src/test/java/fiftyone/ipintelligence/cloud/flowelements/IPIntelligenceCloudEngineTests.java
@@ -29,6 +29,7 @@ import fiftyone.pipeline.core.data.AccessiblePropertyMetaData.ProductMetaData;
 import fiftyone.pipeline.core.data.AccessiblePropertyMetaData.PropertyMetaData;
 import fiftyone.pipeline.core.data.FlowData;
 import fiftyone.pipeline.core.data.IWeightedValue;
+import fiftyone.pipeline.core.data.WktString;
 import fiftyone.pipeline.core.flowelements.Pipeline;
 import fiftyone.pipeline.engines.data.AspectPropertyValue;
 import fiftyone.pipeline.engines.services.MissingPropertyService;
@@ -134,6 +135,46 @@ public class IPIntelligenceCloudEngineTests {
             AspectPropertyValue<InetAddress> value = data.getIp();
             assertTrue(value.hasValue());
             assertEquals(InetAddress.getByName("1.2.3.4"), value.getValue());
+        }
+    }
+
+    /**
+     * A property the cloud reports with the {@code WktString} type (e.g.
+     * {@code Areas}) is wrapped in a {@link WktString}. The cloud serialises it
+     * as an object that holds the text under a {@code "value"} key, so this also
+     * exercises that the text is extracted rather than the object stringified.
+     */
+    @Test
+    public void wktStringProperty_parsedAsWktString() throws Exception {
+        try (IPIntelligenceCloudEngine engine = buildEngine(
+                new PropertyMetaData("areas", "WktString", "cat", null))) {
+
+            IPIntelligenceDataCloud data = process(engine,
+                "{ 'ip': { 'areas': { 'value': 'POLYGON((1 2,3 4,5 6,1 2))' } } }");
+
+            AspectPropertyValue<WktString> value = data.getAreas();
+            assertTrue(value.hasValue());
+            assertEquals("POLYGON((1 2,3 4,5 6,1 2))", value.getValue().getValue());
+        }
+    }
+
+    /**
+     * A property the cloud reports with the {@code Single} type (the .NET
+     * 32-bit float used for e.g. Latitude/Longitude) is parsed into a
+     * {@link Float}, so the typed getter returns the declared type rather than
+     * throwing on an unknown type.
+     */
+    @Test
+    public void singleProperty_parsedAsFloat() throws Exception {
+        try (IPIntelligenceCloudEngine engine = buildEngine(
+                new PropertyMetaData("latitude", "Single", "cat", null))) {
+
+            IPIntelligenceDataCloud data = process(engine,
+                "{ 'ip': { 'latitude': 42.447 } }");
+
+            AspectPropertyValue<Float> value = data.getLatitude();
+            assertTrue(value.hasValue());
+            assertEquals(42.447f, value.getValue(), 0.0001f);
         }
     }
 


### PR DESCRIPTION
Follow-up to #129. The cloud also returns the Areas property as WktString (object-wrapped) and Latitude/Longitude as Single, both of which the engine left unmapped - so the pipeline failed to build (503) or threw at runtime.

## Changes
- Map WktString and Single in the cloud engine, reading Areas from its `{"value":…}` wrapper; mirrors the dotnet engine's type resolution.
- Add offline unit tests covering both new types.