### PR TITLE
FIX: Prefetch Lite hash asset used by integration tests

### DIFF
--- a/ci/fetch-assets.ps1
+++ b/ci/fetch-assets.ps1
@@ -5,7 +5,11 @@ $ErrorActionPreference = "Stop"
 
 $ipIntelligenceData = "$PSSCriptRoot/../ip-intelligence.engine.on-premise/src/main/cxx/ip-intelligence-cxx/ip-intelligence-data"
 
-./steps/fetch-assets.ps1 -IpIntelligenceUrl $IpIntelligenceUrl -Assets '51Degrees-EnterpriseIpiV41.ipi', '51Degrees-LiteIpiV41.ipi'
+# The Lite hash file is not used by this repo, but the integration tests clone
+# ip-intelligence-java-examples and run its fetch-assets, which needs it. Listing
+# it here puts it in the prefetched asset cache, so it is downloaded once per
+# nightly run instead of once per matrix job.
+./steps/fetch-assets.ps1 -IpIntelligenceUrl $IpIntelligenceUrl -Assets '51Degrees-EnterpriseIpiV41.ipi', '51Degrees-LiteIpiV41.ipi', '51Degrees-LiteV4.1.hash'
 New-Item -ItemType SymbolicLink -Force -Target "$PWD/assets/51Degrees-EnterpriseIpiV41.ipi" -Path "$ipIntelligenceData/51Degrees-EnterpriseIpiV41.ipi"
 # The asset is fetched under the blob name, but FileUtils and the data repo
 # scripts use the unpacked name 51Degrees-LiteV41.ipi, so link it as that.


### PR DESCRIPTION
Relates to 51Degrees/common-ci#221. The prefetch step runs this repo's ci/fetch-assets.ps1, which listed only the two .ipi assets, but the integration tests clone ip-intelligence-java-examples and run its fetch-assets, which also needs 51Degrees-LiteV4.1.hash. That left the ~28MB LFS object out of the asset cache, so all 14 matrix jobs downloaded it simultaneously and GitHub reset the connection (run 32327632917). Adding it to the prefetch list downloads it once per nightly run. Pairs with the retry fix in common-ci.